### PR TITLE
queryservice fix

### DIFF
--- a/services/queryService.cfc
+++ b/services/queryService.cfc
@@ -12,7 +12,7 @@ component accessors=true {
       ds = config.datasource;
     }
 
-    if ( !isNull( ds ) ) {
+    if ( !isNull( ds ) && len(trim( ds )) ) {
       setupVendor( utilityService, ds );
     }
 


### PR DESCRIPTION
Added an extra check in case of not null but empty datasources